### PR TITLE
Fix mismatched `rv` version in User-Agent of firefox144/firefox147

### DIFF
--- a/lib/impersonate.c
+++ b/lib/impersonate.c
@@ -1218,7 +1218,7 @@ const struct impersonate_opts impersonations[] = {
       "TLS_RSA_WITH_AES_128_CBC_SHA:"
       "TLS_RSA_WITH_AES_256_CBC_SHA",
     .http_headers = {
-      "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:135.0) Gecko/20100101 Firefox/144.0",
+      "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:144.0) Gecko/20100101 Firefox/144.0",
       "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
       "Accept-Language: en-US,en;q=0.5",
       "Accept-Encoding: gzip, deflate, br, zstd",
@@ -1285,7 +1285,7 @@ const struct impersonate_opts impersonations[] = {
       "TLS_RSA_WITH_AES_128_CBC_SHA:"
       "TLS_RSA_WITH_AES_256_CBC_SHA",
     .http_headers = {
-      "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:135.0) Gecko/20100101 Firefox/147.0",
+      "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:147.0) Gecko/20100101 Firefox/147.0",
       "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
       "Accept-Language: en-US,en;q=0.9",
       "Accept-Encoding: gzip, deflate, br, zstd",


### PR DESCRIPTION
 ## What changed

This PR fixes two Firefox impersonation presets where the UA `rv` version did not match the Firefox version:

- `firefox144`:
  - from `rv:135.0 ... Firefox/144.0`
  - to   `rv:144.0 ... Firefox/144.0`
- `firefox147`:
  - from `rv:135.0 ... Firefox/147.0`
  - to   `rv:147.0 ... Firefox/147.0`

File changed:
- `lib/impersonate.c`

Fixes lexiforest/curl-impersonate#234.

## Why

Firefox UA strings should keep `rv` and `Firefox/` version aligned.
The previous mismatch made these presets internally inconsistent and could hurt impersonation fidelity.

## Scope

Only UA version-token alignment for `firefox144` and `firefox147`.
No behavioral changes outside those two header strings.
